### PR TITLE
Implement environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -39,7 +39,6 @@ dependencies:
 
   # Major modules
   - webbpsf==0.8
-  - webbpsf-data==0.8
 
   # Minor modules
   - pyyaml

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,67 @@
+# This file describes a conda environment that can be to install STIPS
+#
+# Run the following command to set up this environment:
+# $ conda env create -f environment.yml
+#
+# The environment name can be overridden with the following command:
+# $ conda env create -n <custom name> -f environment.yml
+#
+# Run the following command to activate the environment:
+# $ source activate stips
+#
+# To deactivate the environment run the following command:
+# $ source deactivate
+#
+# To remove the environment entirely, run the following command:
+# $ conda env remove -n stips
+
+name: stips
+
+channels:
+  - conda-forge
+  - astropy
+  - http://ssb.stsci.edu/astroconda
+  - defaults
+
+dependencies:
+  # Base dependencies
+  - pip
+  - python>=3.7
+  - Cython
+  - numpy>=1.13
+  - scipy
+  - matplotlib>=3.1.1
+  - astropy
+  - photutils
+  - healpy
+  - pysynphot
+  - esutil
+
+  # Major modules
+  - webbpsf==0.8
+  - webbpsf-data==0.8
+
+  # Minor modules
+  - pyyaml
+  - mechanize
+  - pyfftw
+  - ConfigParser
+
+  # Docs
+  - sphinx
+  - docutils
+  - stsci_rtd_theme
+
+  - pip:
+    # Base dependencies
+    - automodinit
+    - jwst_backgrounds
+
+    # Major modules
+    - pandeia.engine==1.5
+
+    # Minor modules
+    - montage-wrapper
+
+    # Docs
+    - sphinx_astropy


### PR DESCRIPTION
closes #42 

This PR introduces a file, `environment.yml` , with all the conda and pip environmental dependencies. This can be used to install a STIPS environment with the exception of the supporting data for STIPS and Pandea (so all the required modules).  

To test this file you may create a new environment using conda and test if you can import `STIPS`. 

`$ conda env create -n <custom name> -f environment.yml`

`$ conda activate <custom name>`

`$ python` 

`>>> import stips `


If you do not provide a `<custom name>`, the new environment will be named `stips`.

Note that you will get warnings that you do not have the required datasets which you will need to install manually or via Docker. 