### PR TITLE
Adding WCS information to PSF files

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -3,7 +3,7 @@ import numpy as np
 filename = 'example_H158.cat'
 seed = np.random.randint(9999)+1000
 scene_general = {'ra': 25.65,'dec': -37.21,'pa': 0.0, 'seed': seed}
-obs = {'instrument': 'WFI', 'filters': ['H158'], 'detectors': 1,'distortion': False, 'oversample': 1,'pupil_mask': '', 'background': 'avg','observations_id': 69, 'exptime': 10000.0,'offsets': [{'offset_id': 3, 'offset_centre': False,'offset_ra': 0.0, 'offset_dec': 0.0, 'offset_pa': 0.0}]}
+obs = {'instrument': 'WFI', 'filters': ['H158'], 'detectors': 1,'distortion': False, 'oversample': 1,'pupil_mask': '', 'background': 'custom', 'custom_background': 1.5, 'observations_id': 69, 'exptime': 10000.0,'offsets': [{'offset_id': 3, 'offset_centre': False,'offset_ra': 0.0, 'offset_dec': 0.0, 'offset_pa': 0.0}]}
 obm = ObservationModule(obs, scene_general=scene_general)
 obm.nextObservation()
 source_count_catalogues = obm.addCatalogue(str(filename))

--- a/stips/astro_image/astro_image.py
+++ b/stips/astro_image/astro_image.py
@@ -431,8 +431,8 @@ class AstroImage(object):
                     counter += 1
                 self._log('info', 'Finishing Sersic Profiles at {}'.format(time.ctime()))
             ot = Table()
-            ot['x'] = Column(data=xfs, unit='pixels')
-            ot['y'] = Column(data=yfs, unit='pixels')
+            ot['x'] = Column(data=xfs, unit='pixel')
+            ot['y'] = Column(data=yfs, unit='pixel')
             ot['type'] = Column(data=types)
             ot['vegamag'] = Column(data=vegamags)
             ot['stmag'] = Column(data=stmags)
@@ -1127,7 +1127,7 @@ class AstroImage(object):
             w.sip = sip
         self._scale = scale
         message = "{}: (RA, DEC, PA) := ({}, {}, {}), detected as ({}, {}, {})"
-        self._log("info", message.format(self.name, ra, dec, pa, w.wcs.crval[ranum], w.wcs.crval[decnum], self._getPA(w, scale)))
+        self._log("info", message.format(self.name, ra, dec, pa, w.wcs.crval[ranum], w.wcs.crval[decnum], self._getPA(w, scale, decnum)))
         return w
     
     def _normalizeWCS(self,w):
@@ -1137,6 +1137,9 @@ class AstroImage(object):
         elif w.wcs.lattyp == 'RA' and w.wcs.lngtyp == 'DEC':
             ranum = w.wcs.lat
             decnum = w.wcs.lng
+        elif w.wcs.lngtyp.strip() == '' and w.wcs.lattyp.strip() == '':
+            ranum = 0
+            decnum = 1
         else:
             raise ValueError("Lattype = %s and Lngtype = %s: can't get RA, DEC" % (w.wcs.lngtyp,w.wcs.lattyp))
         ra = w.wcs.crval[ranum]

--- a/stips/instruments/wfi.py
+++ b/stips/instruments/wfi.py
@@ -6,6 +6,7 @@ import os
 
 import  numpy as np
 
+from astropy import wcs
 from astropy.io import fits as pyfits
 
 #Local Modules
@@ -68,7 +69,14 @@ class WFI(WfirstInstrument):
             if os.path.exists(os.path.join(self.out_path, "psf_cache")):
                 dest = os.path.join(self.out_path, "psf_cache", "psf_{}_{}_{}.fits".format("WFI", self.filter, self.oversample))
                 pyfits.writeto(dest, psf[0].data, header=psf[0].header, overwrite=True)
-            self.psf = AstroImage(data=psf[0].data, detname="WFI %s PSF" % (self.filter), logger=self.logger)
+            psf_scale = [psf[0].header["PIXELSCL"], psf[0].header["PIXELSCL"]]
+            self.psf = AstroImage(data=psf[0].data, 
+                                  scale=psf_scale, 
+                                  ra=self.ra, 
+                                  dec=self.dec, 
+                                  pa=self.pa, 
+                                  detname="WFI %s PSF" % (self.filter), 
+                                  logger=self.logger)
             self.updateState(base_state)
         
     def generateReadnoise(self):

--- a/stips/instruments/wfi.py
+++ b/stips/instruments/wfi.py
@@ -46,7 +46,14 @@ class WFI(WfirstInstrument):
             if os.path.exists(os.path.join(self.out_path, "psf_cache", "psf_{}_{}_{}.fits".format("WFI", self.filter, self.oversample))):
                 with pyfits.open(os.path.join(self.out_path, "psf_cache", "psf_{}_{}_{}.fits".format("WFI", self.filter, self.oversample))) as psf:
                     if psf[0].header['VERSION'] >= webbpsf.__version__ and (self.psf_commands is None or self.psf_commands == ''):
-                        self.psf = AstroImage(data=psf[0].data, detname="WFI {} PSF".format(self.filter), logger=self.logger)
+                        psf_scale = [psf[0].header["PIXELSCL"], psf[0].header["PIXELSCL"]]
+                        self.psf = AstroImage(data=psf[0].data, 
+                                              scale=psf_scale,
+                                              ra=self.ra,
+                                              dec=self.dec,
+                                              pa=self.pa,
+                                              detname="WFI {} PSF".format(self.filter), 
+                                              logger=self.logger)
                         have_psf = True
         if not have_psf:
             base_state = self.getState()


### PR DESCRIPTION
Closes #43 

PSF files will now have the following:
- RA equal to the observation RA at which they were produced
- DEC equal to the observation DEC at which they were produced
- PA equal to the observation PA at which they were produced
- CDELT keywords equal to the PIXELSCL keyword, but adjusted to degrees rather than arcsec.