### PR TITLE
Dockerfile for STIPS 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ WORKDIR $HOME
 # Place to store data and source
 RUN mkdir -p /opt
 
-# We will copy STScI-STIPS later in the script
-RUN mkdir -p /opt/STScI-STIPS
-
+# Clone STScI-STIPS
+RUN git clone https://github.com/spacetelescope/STScI-STIPS.git
+ENV STIPSDIR $HOME/STScI-STIPS
 
 ##########################
 # Basic apt Requirements #
@@ -84,13 +84,10 @@ ENV LD_LIBRARY_PATH $HOME/lib:$LD_LIBRARY_PATH
 
 WORKDIR $HOME
 
-# Copy STScI-STIPS repo
-COPY . /opt/STScI-STIPS
-
-#RUN conda env update --file /opt/STScI-STIPS/environment.yml
-RUN conda env create -f /opt/STScI-STIPS/environment.yml
+#RUN conda env update --file $STIPSDIR/environment.yml
+RUN conda env create -f $STIPSDIR/environment.yml
 ENV PATH /opt/conda/envs/stips/bin:$PATH
-RUN /bin/bash -c "source activate stips"
+RUN echo "conda activate stips" >> /root/.bashrc
 ENV CONDA_DEFAULT_ENV stips
 
 # Prepare environment variables
@@ -118,8 +115,8 @@ WORKDIR $HOME
 # Install STIPS #
 #################
 
-WORKDIR /opt/STScI-STIPS
-RUN python setup.py install
-
+WORKDIR $STIPSDIR
+RUN python setup.py develop
+ENV stips_data $STIPSDIR/stips/data
 
 WORKDIR $HOME

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,98 @@
+FROM continuumio/miniconda3
+MAINTAINER Space Telescope Science Institute <help@stsci.edu>
+
+# RUN "sh" "-c" "echo nameserver 8.8.8.8 >> /etc/resolv.conf"
+# RUN "sh" "-c" "echo forcing APT update"
+
+ENV HOME /root
+WORKDIR $HOME
+
+# Place to store data and source
+RUN mkdir -p /opt
+
+COPY ./environment.yml /opt/.
+
+
+##########################
+# Basic apt Requirements #
+##########################
+WORKDIR $HOME
+
+RUN apt-get update
+RUN apt-get install -y python3.7
+RUN apt-get install -y python-pip
+RUN apt-get install -y wget
+
+# matplotlib requirement
+RUN apt-get install -y pkg-config
+RUN apt-get install -y libfreetype6-dev
+RUN apt-get install -y rsync
+RUN apt-get install -y git
+
+# SciPy
+RUN apt-get install -y libblas-dev
+RUN apt-get install -y liblapack-dev
+RUN apt-get install -y gfortran
+
+# Update pip
+RUN pip install -U pip
+RUN pip install -U setuptools
+
+
+####################################
+# Install Requirements from Source #
+####################################
+WORKDIR $HOME
+
+# Montage
+WORKDIR /opt
+RUN git clone https://github.com/Caltech-IPAC/Montage.git
+# ADD initdistdata.c ./Montage/lib/src/two_plane_v1.1/initdistdata.c
+WORKDIR /opt/Montage
+RUN make
+RUN pip install montage-wrapper
+ENV PATH /opt/Montage/bin:$PATH
+WORKDIR $HOME
+
+
+##################
+# Reference Data #
+##################
+
+# Install reference data under /opt
+
+WORKDIR /opt
+
+# Extract PySynphot reference data
+RUN wget -qO- http://ssb.stsci.edu/cdbs/tarfiles/synphot1.tar.gz | tar xvz
+RUN wget -qO- http://ssb.stsci.edu/cdbs/tarfiles/synphot2.tar.gz | tar xvz
+RUN wget -qO- http://ssb.stsci.edu/cdbs/tarfiles/synphot5.tar.gz | tar xvz
+ENV PYSYN_CDBS /opt/grp/hst/cdbs
+
+# Extract Pandeia reference data
+RUN wget -qO- https://stsci.box.com/shared/static/5j506xzg9tem2l7ymaqzwqtxne7ts3sr.gz | tar -xvz
+ENV pandeia_refdata /opt/pandeia_data-1.5_wfirst
+
+# Extract WebbPSF reference data
+# (note: version number env vars are declared close to where they are used
+# to prevent unnecessary rebuilds of the Docker image)
+ENV WEBBPSF_DATA_VERSION 0.8.0
+RUN wget -qO- http://www.stsci.edu/~mperrin/software/webbpsf/webbpsf-data-$WEBBPSF_DATA_VERSION.tar.gz | tar xvz
+ENV WEBBPSF_PATH /opt/webbpsf-data
+
+# Prepare environment variables
+ENV PYHOME /opt/conda
+ENV PYTHON_VERSION 3.7
+ENV PATH $HOME/bin:$PATH
+ENV LD_LIBRARY_PATH $HOME/lib:$LD_LIBRARY_PATH
+
+
+######################################
+# Install Conda and Pip Requirements #
+######################################
+
+WORKDIR $HOME
+RUN conda env update --file /opt/environment.yml
+
+# Prepare environment variables
+ENV WEBBPSF_SKIP_CHECK 1


### PR DESCRIPTION
closes #35

This PR introduces a dockerfile for STIPS. The file is based on the `continuumio/miniconda3` image.  This Dockerfile downloads data files, requirements and installs `Pandeia` + `WebbPSF`. To avoid maintaining two Dockerfiles, a [ticket](https://github.com/spacetelescope/wfirst-tools/issues/32) has been created in `spacetelescope/wfirst-tools` to make a Master Dockerfile that installs `Pandeia` and `WebbPSF`.

### Testing 
Testing requires Docker to be installed on your local computer. For instructions on this please visit the `spacetelescope/wfirst-tools` repo. 

You can build the following docker file by running this command at the top level of your local STScI-STIPS dir (make sure to use the native terminal of your MacBook not Iterm2):
`docker build -t stips .` 

This will take a long while to build. If there is an error the build will fail.

You can then fire up a terminal in the docker image by running the following command:
`docker run -it stips`

You can then open `ipython` and `import stips` to check if it installed correctly.