### PR TITLE
Move STIPS from PYSYNPHOT to synphot/stsynphot

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -13,6 +13,7 @@ dependencies:
   # Docs
   - sphinx
   - docutils
+  - sphinx_rtd_theme
   - stsci_rtd_theme
 
   - pip:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ addons:
 env:
     global:
         # Define Conda Version
-        - MINICONDA_VERSION=py38_4.8.3
+        - MINICONDA_VERSION=py37_4.8.3
     
         # The following versions are the 'default' for tests, unless
         # overridden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - PYTHON_VERSION=3.8
+        - PYTHON_VERSION=3.7
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - MAIN_CMD='python setup.py'

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ addons:
 
 env:
     global:
+        # Define Conda Version
+        - MINICONDA_VERSION=4.8.5
+    
         # The following versions are the 'default' for tests, unless
         # overridden underneath. They are defined here in order to save having
         # to repeat them for all configurations.

--- a/.travis.yml
+++ b/.travis.yml
@@ -140,9 +140,9 @@ before_install:
     - export PYSYN_CDBS=$TEST_DATA_PATH/synphot/grp/hst/cdbs
 
     # download pandeia_data data
-    - wget -qO- https://stsci.box.com/shared/static/7voehzi5krrpml5wgyg8bo954ew7arh2.gz -O $TEST_DATA_PATH/pandeia_data-1.5_wfirst.gz
+    - wget -qO- https://stsci.box.com/shared/static/7voehzi5krrpml5wgyg8bo954ew7arh2.gz -O $TEST_DATA_PATH/pandeia_data-1.5.2rc2_roman.gz
 
-    - tar -xzvf $TEST_DATA_PATH/pandeia_data-1.5_wfirst.gz -C $TEST_DATA_PATH/
+    - tar -xzvf $TEST_DATA_PATH/pandeia_data-1.5.2rc2_roman.gz -C $TEST_DATA_PATH/
     - export pandeia_refdata=$TEST_DATA_PATH/pandeia_data-1.5.2rc2_roman
 
     # download webbpsf data

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ before_install:
     - wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot1.tar.gz -O $TEST_DATA_PATH/synphot1.tar.gz
     - wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot2.tar.gz -O $TEST_DATA_PATH/synphot2.tar.gz
     - wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot5.tar.gz -O $TEST_DATA_PATH/synphot5.tar.gz
-    - wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot6.tar.gz -O $TEST_DATA_PATH/synphot5.tar.gz
+    - wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot6.tar.gz -O $TEST_DATA_PATH/synphot6.tar.gz
 
     - tar -xzvf $TEST_DATA_PATH/synphot1.tar.gz -C $TEST_DATA_PATH/synphot/
     - tar -xzvf $TEST_DATA_PATH/synphot2.tar.gz -C $TEST_DATA_PATH/synphot/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ addons:
 env:
     global:
         # Define Conda Version
-        - MINICONDA_VERSION=4.8.0
+        - MINICONDA_VERSION=py38_4.8.3
     
         # The following versions are the 'default' for tests, unless
         # overridden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - PYTHON_VERSION=3.7
+        - PYTHON_VERSION=3.8
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - MAIN_CMD='python setup.py'

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
 env:
     global:
         # Define Conda Version
-        - MINICONDA_VERSION=4.8.3
+        - MINICONDA_VERSION=latest
     
         # The following versions are the 'default' for tests, unless
         # overridden underneath. They are defined here in order to save having

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,13 +127,15 @@ before_install:
     # download synphot data
     - mkdir $TEST_DATA_PATH/synphot
 
-    - wget -qO- http://ssb.stsci.edu/cdbs/tarfiles/synphot1.tar.gz -O $TEST_DATA_PATH/synphot1.tar.gz
-    - wget -qO- http://ssb.stsci.edu/cdbs/tarfiles/synphot2.tar.gz -O $TEST_DATA_PATH/synphot2.tar.gz
-    - wget -qO- http://ssb.stsci.edu/cdbs/tarfiles/synphot5.tar.gz -O $TEST_DATA_PATH/synphot5.tar.gz
+    - wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot1.tar.gz -O $TEST_DATA_PATH/synphot1.tar.gz
+    - wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot2.tar.gz -O $TEST_DATA_PATH/synphot2.tar.gz
+    - wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot5.tar.gz -O $TEST_DATA_PATH/synphot5.tar.gz
+    - wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot6.tar.gz -O $TEST_DATA_PATH/synphot5.tar.gz
 
     - tar -xzvf $TEST_DATA_PATH/synphot1.tar.gz -C $TEST_DATA_PATH/synphot/
     - tar -xzvf $TEST_DATA_PATH/synphot2.tar.gz -C $TEST_DATA_PATH/synphot/
     - tar -xzvf $TEST_DATA_PATH/synphot5.tar.gz -C $TEST_DATA_PATH/synphot/
+    - tar -xzvf $TEST_DATA_PATH/synphot6.tar.gz -C $TEST_DATA_PATH/synphot/
 
     - export PYSYN_CDBS=$TEST_DATA_PATH/synphot/grp/hst/cdbs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
 env:
     global:
         # Define Conda Version
-        - MINICONDA_VERSION=latest
+        - MINICONDA_VERSION=4.8.0
     
         # The following versions are the 'default' for tests, unless
         # overridden underneath. They are defined here in order to save having

--- a/.travis.yml
+++ b/.travis.yml
@@ -140,7 +140,7 @@ before_install:
     - export PYSYN_CDBS=$TEST_DATA_PATH/synphot/grp/hst/cdbs
 
     # download pandeia_data data
-    - wget -qO- https://stsci.box.com/shared/static/5j506xzg9tem2l7ymaqzwqtxne7ts3sr.gz -O $TEST_DATA_PATH/pandeia_data-1.5_wfirst.gz
+    - wget -qO- https://stsci.box.com/shared/static/7voehzi5krrpml5wgyg8bo954ew7arh2.gz -O $TEST_DATA_PATH/pandeia_data-1.5_wfirst.gz
 
     - tar -xzvf $TEST_DATA_PATH/pandeia_data-1.5_wfirst.gz -C $TEST_DATA_PATH/
     - export pandeia_refdata=$TEST_DATA_PATH/pandeia_data-1.5_wfirst

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ matrix:
         - name: "Doc Build Test"
           os: linux
           env: SETUP_CMD='build_docs -w'
-               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_DOC
+               CONDA_ENVIRONMENT='.rtd-environment.yml'
 
         # Main test
         # ---------------------------

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
 env:
     global:
         # Define Conda Version
-        - MINICONDA_VERSION=4.8.5
+        - MINICONDA_VERSION=4.8.3
     
         # The following versions are the 'default' for tests, unless
         # overridden underneath. They are defined here in order to save having

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ before_install:
     - wget -qO- https://stsci.box.com/shared/static/7voehzi5krrpml5wgyg8bo954ew7arh2.gz -O $TEST_DATA_PATH/pandeia_data-1.5_wfirst.gz
 
     - tar -xzvf $TEST_DATA_PATH/pandeia_data-1.5_wfirst.gz -C $TEST_DATA_PATH/
-    - export pandeia_refdata=$TEST_DATA_PATH/pandeia_data-1.5_wfirst
+    - export pandeia_refdata=$TEST_DATA_PATH/pandeia_data-1.5.2rc2_roman
 
     # download webbpsf data
     - wget -qO- https://stsci.box.com/shared/static/qcptcokkbx7fgi3c00w2732yezkxzb99.gz -O $TEST_DATA_PATH/webbpsf_data.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ ENV PYSYN_CDBS /opt/grp/hst/cdbs
 
 # Extract Pandeia reference data
 RUN wget -qO- https://stsci.box.com/shared/static/7voehzi5krrpml5wgyg8bo954ew7arh2.gz | tar -xvz
-ENV pandeia_refdata /opt/pandeia_data-1.5_wfirst
+ENV pandeia_refdata /opt/pandeia_data-1.5.2rc2_roman
 
 # Extract WebbPSF reference data
 # (note: version number env vars are declared close to where they are used

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,8 +66,8 @@ RUN wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot6.tar.gz | tar xvz
 ENV PYSYN_CDBS /opt/grp/hst/cdbs
 
 # Extract Pandeia reference data
-RUN wget -qO- https://stsci.box.com/shared/static/5j506xzg9tem2l7ymaqzwqtxne7ts3sr.gz | tar -xvz
-ENV pandeia_refdata /opt/pandeia_data-1.5.2_wfirst
+RUN wget -qO- https://stsci.box.com/shared/static/7voehzi5krrpml5wgyg8bo954ew7arh2.gz | tar -xvz
+ENV pandeia_refdata /opt/pandeia_data-1.5_wfirst
 
 # Extract WebbPSF reference data
 # (note: version number env vars are declared close to where they are used

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,14 +59,15 @@ RUN wget -qO- https://stsci.box.com/shared/static/iufbhsiu0lts16wmdsi12cun25888n
 ENV stips_data /opt/stips_data
 
 # Extract PySynphot reference data
-RUN wget -qO- http://ssb.stsci.edu/cdbs/tarfiles/synphot1.tar.gz | tar xvz
-RUN wget -qO- http://ssb.stsci.edu/cdbs/tarfiles/synphot2.tar.gz | tar xvz
-RUN wget -qO- http://ssb.stsci.edu/cdbs/tarfiles/synphot5.tar.gz | tar xvz
+RUN wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot1.tar.gz | tar xvz
+RUN wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot2.tar.gz | tar xvz
+RUN wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot5.tar.gz | tar xvz
+RUN wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot6.tar.gz | tar xvz
 ENV PYSYN_CDBS /opt/grp/hst/cdbs
 
 # Extract Pandeia reference data
 RUN wget -qO- https://stsci.box.com/shared/static/5j506xzg9tem2l7ymaqzwqtxne7ts3sr.gz | tar -xvz
-ENV pandeia_refdata /opt/pandeia_data-1.5_wfirst
+ENV pandeia_refdata /opt/pandeia_data-1.5.2_wfirst
 
 # Extract WebbPSF reference data
 # (note: version number env vars are declared close to where they are used

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+|Travis Status| |PyPI Status|
+
 # STScI-STIPS
 
 For documentation and installation instructions please visit https://stsci-stips.readthedocs.io

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,9 +23,9 @@ STIPS Requirements
 * `numpy`: STIPS uses numpy extensively for almost everything that it does.
 * `photutils`: STIPS uses photutils to determine the flux inside the half-light radius
   in generated Sersic profiles.
-* `pysynphot`: STIPS uses pysynphot to generate bandpasses, count rates, and
-  zero points. Note that pysynphot's data files (also known as the CDBS data tree) must also be
-  installed and available as indicated in pysynphot's documentation.
+* `synphot` and `stsynphot`: STIPS uses synphot and stsynphot to generate 
+  bandpasses, count rates, and zero points. Note that the reference data must
+  also be downloaded, as described below in "Doanloading Required Data".
 * `scipy`: STIPS uses scipy to manipulate its internal images (zoom and rotate).
 
 Finally, STIPS requires a set of data files whose location is marked by setting the environment
@@ -99,10 +99,11 @@ You will need to download the data and add them to your environmental path
 
 2. `cd` into a directory you would like to store the data in and run the following commands::
 
-    # PySynphot reference data
-    wget -qO- http://ssb.stsci.edu/cdbs/tarfiles/synphot1.tar.gz | tar xvz
-    wget -qO- http://ssb.stsci.edu/cdbs/tarfiles/synphot2.tar.gz | tar xvz
-    wget -qO- http://ssb.stsci.edu/cdbs/tarfiles/synphot5.tar.gz | tar xvz
+    # Synphot and STSynphot reference data
+    wget -qO- http://ssb.stsci.edu/trds/tarfiles/synphot1.tar.gz | tar xvz
+    wget -qO- http://ssb.stsci.edu/trds/tarfiles/synphot2.tar.gz | tar xvz
+    wget -qO- http://ssb.stsci.edu/trds/tarfiles/synphot5.tar.gz | tar xvz
+    wget -qO- http://ssb.stsci.edu/trds/tarfiles/synphot6.tar.gz | tar xvz
 
 
     # Pandeia reference data

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -100,10 +100,10 @@ You will need to download the data and add them to your environmental path
 2. `cd` into a directory you would like to store the data in and run the following commands::
 
     # Synphot and STSynphot reference data
-    wget -qO- http://ssb.stsci.edu/trds/tarfiles/synphot1.tar.gz | tar xvz
-    wget -qO- http://ssb.stsci.edu/trds/tarfiles/synphot2.tar.gz | tar xvz
-    wget -qO- http://ssb.stsci.edu/trds/tarfiles/synphot5.tar.gz | tar xvz
-    wget -qO- http://ssb.stsci.edu/trds/tarfiles/synphot6.tar.gz | tar xvz
+    wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot1.tar.gz | tar xvz
+    wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot2.tar.gz | tar xvz
+    wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot5.tar.gz | tar xvz
+    wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot6.tar.gz | tar xvz
 
 
     # Pandeia reference data
@@ -116,9 +116,9 @@ You will need to download the data and add them to your environmental path
 
     export WEBBPSF_PATH=/<path_to_data_dir>/webbpsf-data
     export PYSYN_CDBS=/<path_to_data_dir>/grp/hst/cdbs
-    export pandeia_refdata=/<path_to_data_dir>/pandeia_data-x.x_wfirst
+    export pandeia_refdata=/<path_to_data_dir>/pandeia_data-x.x.x_roman
 
-Make sure that you have the correct version number for `pandeia_refdata` (replace the "x.x").
+Make sure that you have the correct version number for `pandeia_refdata` (replace the "x.x.x").
 
 .. note::
     The URL we provide in this section and the suggested pandeia reference data directory name

--- a/environment.yml
+++ b/environment.yml
@@ -58,7 +58,7 @@ dependencies:
 
   - pip:
     # Major modules
-    - pandeia.engine>=1.5.2
+    - pandeia.engine==1.5.2
     - jwst_backgrounds
 
     # Minor modules

--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,8 @@ dependencies:
   - astropy
   - photutils
   - healpy
-  - pysynphot
+  - synphot
+  - stsynphot
   - esutil
 
   # Major modules
@@ -57,7 +58,7 @@ dependencies:
 
   - pip:
     # Major modules
-    - pandeia.engine==1.5
+    - pandeia.engine>=1.5
     - jwst_backgrounds
 
     # Minor modules

--- a/environment.yml
+++ b/environment.yml
@@ -58,7 +58,7 @@ dependencies:
 
   - pip:
     # Major modules
-    - pandeia.engine>=1.5
+    - pandeia.engine>=1.5.2
     - jwst_backgrounds
 
     # Minor modules

--- a/stips/astro_image/astro_image.py
+++ b/stips/astro_image/astro_image.py
@@ -168,7 +168,7 @@ class AstroImage(object):
 
     
     def __del__(self):
-        if os.path.exists(self.fname):
+        if hasattr(self, 'fname') and os.path.exists(self.fname):
             os.remove(self.fname)
 
     def copy(self):

--- a/stips/instruments/instrument.py
+++ b/stips/instruments/instrument.py
@@ -992,8 +992,10 @@ class Instrument(object):
         #   Conversion: * self.SCALE[0] * self.SCALE[1] for arcsec^-2 -> pixel^-2
         flux_array_pixels = 1e9 * flux_array * 2.3504e-11 * self.SCALE[0] * self.SCALE[1]
     
-        sp = syn.SourceSpectrum(syn.Empirical1D, points=wave_array, lookup_table=flux_array_pixels)
-        obs = syn.Observation(sp, self.bandpass, binset=sp.waveset, force='taper')
+        sp = syn.SourceSpectrum(syn.Empirical1D, points=wave_array*u.micron, 
+                                lookup_table=flux_array_pixels)
+        obs = syn.Observation(sp, self.bandpass, binset=sp.waveset, 
+                              force='taper')
         bg = obs.countrate(area=self.AREA)
         
         self._log("info", "Returning background {} for '{}'".format(bg, self.background_value))

--- a/stips/instruments/instrument.py
+++ b/stips/instruments/instrument.py
@@ -5,8 +5,10 @@ __filetype__ = "base"
 import glob, logging, os, shutil, sys, types, uuid
 
 import numpy as np
-import pysynphot as ps
+import synphot as syn
+import stsynphot as stsyn
 
+from astropy import units as u
 from astropy.io import fits as pyfits
 from astropy.table import Table, Column
 from functools import wraps
@@ -464,7 +466,7 @@ class Instrument(object):
             idx = np.where(datasets == dataset)
             if len(idx[0]) > 0:
                 stargen = StarGenerator(ages[idx][0], metallicities[idx][0], seed=self.seed, logger=self.logger)
-                rates[idx] = stargen.make_cluster_rates(masses[idx], self.DETECTOR, self.filter, bp, self.REFS)
+                rates[idx] = stargen.make_cluster_rates(masses[idx], self, bp)
                 del stargen
         rates = rates * 100 / (distances**2) #convert absolute to apparent rates
         if cached > 0:
@@ -509,7 +511,6 @@ class Instrument(object):
         """
         if table is None:
             return None
-        ps.setref(**self.REFS)
         ids = table['id']
         ras = table['ra']
         decs = table['dec']
@@ -523,10 +524,10 @@ class Instrument(object):
         rates = np.zeros_like(ras)
         for index in range(len(ids)):
             t, g, Z, a = temps[index], gravs[index], metallicities[index], apparents[index]
-            sp = ps.Icat('phoenix', t, Z, g)
+            sp = stsyn.grid_to_spec('phoenix', t, Z, g)
             sp = self.normalize(sp, a, norm_bp)
-            obs = ps.Observation(sp, bp, binset=sp.wave)
-            rates[index] = obs.countrate()
+            obs = syn.Observation(sp, bp, binset=sp.waveset)
+            rates[index] = obs.countrate(area=self.AREA)
         t = Table()
         t['ra'] = Column(data=ras)
         t['dec'] = Column(data=decs)
@@ -549,7 +550,6 @@ class Instrument(object):
         if table is None:
             return None
         from pandeia.engine.sed import SEDFactory
-        ps.setref(**self.REFS)
         ids = table['id']
         ras = table['ra']
         decs = table['dec']
@@ -564,8 +564,8 @@ class Instrument(object):
             spectrum = SEDFactory(config=config)
             wave, flux = spectrum.get_spectrum()
             sp = self.normalize((wave, flux), a, norm_bp)
-            obs = ps.Observation(sp, bp, binset=sp.wave)
-            rates = np.append(rates, obs.countrate())
+            obs = syn.Observation(sp, bp, binset=sp.wave)
+            rates = np.append(rates, obs.countrate(area=self.AREA))
         t = Table()
         t['ra'] = Column(data=ras)
         t['dec'] = Column(data=decs)
@@ -584,6 +584,7 @@ class Instrument(object):
         """
         Converts a BC95 galaxy grid of sources into the internal source table standard
         """
+        from pandeia.engine.custom_exceptions import SynphotError as pSynError
         if table is None:
             return None
         # This function is needed because I can't get python not to read '50E8' as a number, or to output it as a correctly formatted string
@@ -593,10 +594,8 @@ class Instrument(object):
             value = int(10*(num/(10**np.floor(np.log10(num)))))
             return "{}E{}".format(value, exponent-1)
         
-        from pandeia.engine.custom_exceptions import PysynphotError
         self._log("info", "Converting BC95 Catalogue")
         proflist = {"expdisk":1,"devauc":4}
-        ps.setref(**self.REFS)
         distance_type = "redshift"
         ids = table['id']
         ras = table['ra']
@@ -626,18 +625,21 @@ class Instrument(object):
 #             self._log("info", "{} of {}: {} {} {} {} {} {} {} {}".format(i, total, z, model, age, profile, radius, ratio, pa, mag))
             fname = "bc95_{}_{}.fits".format(model, stringify(age))
             try:
-                sp = ps.FileSpectrum(os.path.join(os.environ['PYSYN_CDBS'],"grid","bc95","templates",fname))
+                sp = syn.SourceSpectrum.from_file(os.path.join(os.environ['PYSYN_CDBS'],"grid","bc95","templates",fname))
                 if distance_type == "redshift":
-                    sp = sp.redshift(z)
+                    sp = syn.SourceSpectrum(sp.model, z=z)
                 sp = self.normalize(sp, mag, norm_bp)
-                obs = ps.Observation(sp, self.bandpass, force='taper', binset=sp.wave)
-                rate = obs.countrate()
-            except PysynphotError as e:
-                self._log('warning', 'Source {} of {}: Pysynphot Error {} encountered'.format(i, total, e))
+                obs = syn.Observation(sp, self.bandpass, force='taper', 
+                                      binset=sp.waveset)
+                rate = obs.countrate(area=self.AREA).value
+            except pSynError as e:
+                msg = 'Source {} of {}: Pysynphot Error {} encountered'
+                self._log('warning', msg.format(i, total, e))
                 rate = 0.
-            rates = np.append(rates,rate)
-            indices = np.append(indices,proflist[profile])
-            notes = np.append(notes,"BC95_{}_{}_{}".format(model, stringify(age), mag))
+            rates = np.append(rates, rate)
+            indices = np.append(indices, proflist[profile])
+            note = "BC95_{}_{}_{}".format(model, stringify(age), mag)
+            notes = np.append(notes, note)
         t = Table()
         t['ra'] = Column(data=ras, dtype=np.float)
         t['dec'] = Column(data=decs)
@@ -854,10 +856,10 @@ class Instrument(object):
         if isinstance(source_spectrum_or_wave_flux, tuple):
             wave, flux = source_spectrum_or_wave_flux
         else:
-            wave, flux = norm.from_pysynphot(source_spectrum_or_wave_flux)
+            wave = source_spectrum_or_wave_flux.waveset
+            flux = source_spectrum_or_wave_flux(wave)
         norm_wave, norm_flux = norm.normalize(wave, flux)
-        sp = norm.to_pysynphot(norm_wave, norm_flux)
-        sp.convert('angstroms')
+        sp = syn.SourceSpectrum(syn.Empirical1D, points=norm_wave, lookup_table=norm_flux)
         return sp
     
     def get_type(self, bandpass_str):
@@ -892,8 +894,8 @@ class Instrument(object):
             wave = np.append(wave, wave[-1]+(wave[-1]-wave[-2]))
             pce = np.append(pce, 0.)
         
-        self._bp = ps.ArrayBandpass(wave=wave, throughput=pce, waveunits='micron', name='bp_{}_{}'.format(self.instrument, self.filter))
-        self._bp.convert('angstroms')
+        self._bp = syn.SpectralElement(syn.Empirical1D, points=wave*u.micron, 
+                                       lookup_table=pce)
         return self._bp
     
     @property
@@ -920,28 +922,29 @@ class Instrument(object):
     
     @property
     def zeropoint(self):
-        ps.setref(**self.REFS)
-        standard_star_file = GetStipsData(os.path.join("standards", "alpha_lyr_stis_008.fits"))
-        sp = ps.FileSpectrum(standard_star_file)
-        sp.convert('angstroms')
+        sp = syn.SourceSpectrum.from_vega()
         bp = self.bandpass
-        sp = sp.renorm(0.0,"VEGAMAG",bp)
-        obs = ps.Observation(sp, bp, binset=sp.wave)
-        zeropoint = obs.effstim("OBMAG")
+        obs = syn.Observation(sp, bp, binset=sp.waveset)
+        zeropoint = obs.effstim(flux_unit=u.ABmag).value
         return zeropoint
     
     @property
-    def photflam(self):
-        ps.setref(**self.REFS)
-        sp = ps.FlatSpectrum(0, fluxunits='stmag')
-        sp.convert('angstroms')
+    def unit_photflam(self):
+        sp = syn.SourceSpectrum(syn.ConstFlux1D, amplitude=(0.*u.STmag))
         bp = self.bandpass
-        obs = ps.Observation(sp, bp, binset=sp.wave)
-        return obs.effstim('flam') / obs.countrate()
+        obs = syn.Observation(sp, bp, binset=sp.waveset)
+        pf = (obs.effstim(flux_unit='flam') / obs.countrate(area=self.AREA))
+        return pf
+    
+    @property
+    def photflam(self):
+        return self.unit_photflam.value
     
     @property
     def pixel_background(self):
-        if self.background_value == 'none':
+        if isinstance(self.background_value, (int, float)):
+            return self.background_value
+        elif self.background_value == 'none':
             self._log("info", "Returning background 0.0 for 'none'")
             return 0.
         elif self.background_value == 'custom':
@@ -989,12 +992,9 @@ class Instrument(object):
         #   Conversion: * self.SCALE[0] * self.SCALE[1] for arcsec^-2 -> pixel^-2
         flux_array_pixels = 1e9 * flux_array * 2.3504e-11 * self.SCALE[0] * self.SCALE[1]
     
-        ps.setref(**self.REFS)
-        sp = ps.ArraySpectrum(wave_array, flux_array_pixels, waveunits='micron', fluxunits='mjy')
-        sp.convert('angstroms')
-        sp.convert('photlam')
-        obs = ps.Observation(sp, self.bandpass, binset=sp.wave, force='taper')
-        bg = obs.countrate()
+        sp = syn.SourceSpectrum(syn.Empirical1D, points=wave_array, lookup_table=flux_array_pixels)
+        obs = syn.Observation(sp, self.bandpass, binset=sp.waveset, force='taper')
+        bg = obs.countrate(area=self.AREA)
         
         self._log("info", "Returning background {} for '{}'".format(bg, self.background_value))
         return bg

--- a/stips/instruments/instrument.py
+++ b/stips/instruments/instrument.py
@@ -929,7 +929,11 @@ class Instrument(object):
         return zeropoint
     
     @property
-    def unit_photflam(self):
+    def photflam(self):
+        return self.photflam_unit.value
+    
+    @property
+    def photflam_unit(self):
         sp = syn.SourceSpectrum(syn.ConstFlux1D, amplitude=(0.*u.STmag))
         bp = self.bandpass
         obs = syn.Observation(sp, bp, binset=sp.waveset)
@@ -937,11 +941,11 @@ class Instrument(object):
         return pf
     
     @property
-    def photflam(self):
-        return self.unit_photflam.value
+    def pixel_background(self):
+        return self.pixel_background_unit.value
     
     @property
-    def pixel_background(self):
+    def pixel_background_unit(self):
         if isinstance(self.background_value, (int, float)):
             return self.background_value
         elif self.background_value == 'none':

--- a/stips/instruments/wfc3ir.py
+++ b/stips/instruments/wfc3ir.py
@@ -3,6 +3,7 @@ __filetype__ = "detector"
 
 #External Modules
 import os
+import stsynphot as stsyn
 
 #Local Modules
 from ..astro_image import AstroImage
@@ -42,10 +43,8 @@ class WFC3IR(HstInstrument):
 
     @property
     def bandpass(self):
-        import pysynphot as ps
-        ps.setref(**self.REFS)
         obsmode = "wfc3,ir," + self.filter.lower()
-        return ps.ObsBandpass(obsmode)
+        return stsyn.band(obsmode)
             
     def generateReadnoise(self):
         """


### PR DESCRIPTION
Moves STIPS to a set of packages that will continue to be supported.

Makes STIPS compatible with pandeia >= 1.5.2.

Closes #96 