### PR TITLE
Add GitHub actions CI suite

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -38,10 +38,32 @@ jobs:
     - name: Install base dependencies
       run: |
         $CONDA/bin/conda env update --file environment.yml --name base
+    - name: Install Required Data
+      run: |
+        mkdir test_data
+        wget https://stsci.box.com/shared/static/4nebx2ndxr7c77lgocfbvxo7c2hyd3in.tgz -O test_data/stips_data_current.tar.gz
+        tar -xzvf test_data/stips_data_current.tar.gz -C test_data
+        mkdir test_data/synphot
+        wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot1.tar.gz -O test_data/synphot1.tar.gz
+        tar -xzvf test_data/synphot1.tar.gz -C test_data/synphot/
+        wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot2.tar.gz -O test_data/synphot2.tar.gz
+        tar -xzvf test_data/synphot2.tar.gz -C test_data/synphot/
+        wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot5.tar.gz -O test_data/synphot5.tar.gz
+        tar -xzvf test_data/synphot5.tar.gz -C test_data/synphot/
+        wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot6.tar.gz -O test_data/synphot6.tar.gz
+        tar -xzvf test_data/synphot6.tar.gz -C test_data/synphot/
+        wget -qO- https://stsci.box.com/shared/static/7voehzi5krrpml5wgyg8bo954ew7arh2.gz -O test_data/pandeia_data-1.5.2rc2_roman.gz
+        tar -xzvf test_data/pandeia_data-1.5.2rc2_roman.gz -C test_data/
+        wget -qO- https://stsci.box.com/shared/static/qcptcokkbx7fgi3c00w2732yezkxzb99.gz -O test_data/webbpsf_data.gz
+        tar -xzvf test_data/webbpsf_data.gz -C test_data/
     - name: Test with pytest
       run: |
+        export stips_data=./test_data/stips_data
+        export PYSYN_CDBS=./test_data/synphot/grp/hst/cdbs
+        export pandeia_refdata=./test_data/pandeia_data-1.5.2rc2_roman
+        export WEBBPSF_PATH=./test_data/webbpsf-data
         $CONDA/bin/conda install pytest
-        $CONDA/bin/pytest -m "not veryslow"
+        $CONDA/bin/pytest -m "not veryslow" stips
 
   mac_ci_test:
     name: macOS - Python 3.8
@@ -57,11 +79,33 @@ jobs:
         python-version: 3.8
     - name: Install base dependencies
       run: |
-        sudo $CONDA/bin/conda env update --file environment.yml --name base
+        $CONDA/bin/conda env update --file environment.yml --name base
+    - name: Install Required Data
+      run: |
+        mkdir test_data
+        wget https://stsci.box.com/shared/static/4nebx2ndxr7c77lgocfbvxo7c2hyd3in.tgz -O test_data/stips_data_current.tar.gz
+        tar -xzvf test_data/stips_data_current.tar.gz -C test_data
+        mkdir test_data/synphot
+        wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot1.tar.gz -O test_data/synphot1.tar.gz
+        tar -xzvf test_data/synphot1.tar.gz -C test_data/synphot/
+        wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot2.tar.gz -O test_data/synphot2.tar.gz
+        tar -xzvf test_data/synphot2.tar.gz -C test_data/synphot/
+        wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot5.tar.gz -O test_data/synphot5.tar.gz
+        tar -xzvf test_data/synphot5.tar.gz -C test_data/synphot/
+        wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot6.tar.gz -O test_data/synphot6.tar.gz
+        tar -xzvf test_data/synphot6.tar.gz -C test_data/synphot/
+        wget -qO- https://stsci.box.com/shared/static/7voehzi5krrpml5wgyg8bo954ew7arh2.gz -O test_data/pandeia_data-1.5.2rc2_roman.gz
+        tar -xzvf test_data/pandeia_data-1.5.2rc2_roman.gz -C test_data/
+        wget -qO- https://stsci.box.com/shared/static/qcptcokkbx7fgi3c00w2732yezkxzb99.gz -O test_data/webbpsf_data.gz
+        tar -xzvf test_data/webbpsf_data.gz -C test_data/
     - name: Test with pytest
       run: |
+        export stips_data=./test_data/stips_data
+        export PYSYN_CDBS=./test_data/synphot/grp/hst/cdbs
+        export pandeia_refdata=./test_data/pandeia_data-1.5.2rc2_roman
+        export WEBBPSF_PATH=./test_data/webbpsf-data
         $CONDA/bin/conda install pytest
-        $CONDA/bin/pytest -m "not veryslow"
+        $CONDA/bin/pytest -m "not veryslow" stips
 
   docs_test:
     name: "docs_test"

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -26,10 +26,6 @@ jobs:
             os: ubuntu-latest
             python: 3.8
 
-          - name: OS X - Python 3.8
-            os: macos-latest
-            python: 3.8
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -41,6 +37,27 @@ jobs:
         python-version: ${{ matrix.python }}
     - name: Install base dependencies
       run: |
+        $CONDA/bin/conda env update --file environment.yml --name base
+    - name: Test with pytest
+      run: |
+        $CONDA/bin/conda install pytest
+        $CONDA/bin/pytest -m "not veryslow"
+
+  mac_ci_test:
+    name: macOS - Python 3.8
+    runs-on: macos-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up python 3.8 on macos-latest
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install base dependencies
+      run: |
+        sudo chown 501:20 /usr/local/miniconda/pkgs/cache/31ce02e0.json
         $CONDA/bin/conda env update --file environment.yml --name base
     - name: Test with pytest
       run: |
@@ -62,7 +79,7 @@ jobs:
     - name: Install base dependencies
       run: |
         $CONDA/bin/conda env update --file .rtd-environment.yml --name base
-    - name: Test with pytest
+    - name: Build Docs
       run: |
         $CONDA/bin/python setup.py build_docs -w
 
@@ -81,7 +98,30 @@ jobs:
     - name: Install base dependencies
       run: |
         $CONDA/bin/conda env update --file environment.yml --name base
+    - name: Install Required Data
+      run: |
+        mkdir test_data
+        wget https://stsci.box.com/shared/static/4nebx2ndxr7c77lgocfbvxo7c2hyd3in.tgz -O test_data/stips_data_current.tar.gz
+        tar -xzvf test_data/stips_data_current.tar.gz -C test_data
+        mkdir test_data/synphot
+        wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot1.tar.gz -O test_data/synphot1.tar.gz
+        tar -xzvf test_data/synphot1.tar.gz -C test_data/synphot/
+        wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot2.tar.gz -O test_data/synphot2.tar.gz
+        tar -xzvf test_data/synphot2.tar.gz -C test_data/synphot/
+        wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot5.tar.gz -O test_data/synphot5.tar.gz
+        tar -xzvf test_data/synphot5.tar.gz -C test_data/synphot/
+        wget -qO- https://ssb.stsci.edu/trds/tarfiles/synphot6.tar.gz -O test_data/synphot6.tar.gz
+        tar -xzvf test_data/synphot6.tar.gz -C test_data/synphot/
+        wget -qO- https://stsci.box.com/shared/static/7voehzi5krrpml5wgyg8bo954ew7arh2.gz -O test_data/pandeia_data-1.5.2rc2_roman.gz
+        tar -xzvf test_data/pandeia_data-1.5.2rc2_roman.gz -C test_data/
+        wget -qO- https://stsci.box.com/shared/static/qcptcokkbx7fgi3c00w2732yezkxzb99.gz -O test_data/webbpsf_data.gz
+        tar -xzvf test_data/webbpsf_data.gz -C test_data/
     - name: Test with pytest
       run: |
+        export stips_data=./test_data/stips_data
+        export PYSYN_CDBS=./test_data/synphot/grp/hst/cdbs
+        export pandeia_refdata=./test_data/pandeia_data-1.5.2rc2_roman
+        export WEBBPSF_PATH=./test_data/webbpsf-data
         $CONDA/bin/conda install pytest
         $CONDA/bin/pytest
+

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Set up environment
       uses: conda-incubator/setup-miniconda@v2
       with:
-        activate-environment: test
+        activate-environment: stips
         environment-file: environment.yml
         python-version: 3.8
         auto-activate-base: false
@@ -105,7 +105,7 @@ jobs:
         export pandeia_refdata=./test_data/pandeia_data-1.5.2rc2_roman
         export WEBBPSF_PATH=./test_data/webbpsf-data
         conda install pytest
-        pytest -m "not veryslow" stips
+        $CONDA/envs/stips/bin/pytest -m "not veryslow" stips
 
   docs_test:
     name: "docs_test"

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -1,0 +1,87 @@
+# GitHub Actions workflow for testing and continuous integration.
+
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ci_tests:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+
+          - name: Python 2.7
+            os: ubuntu-latest
+            python: 2.7
+
+          - name: Python 3.7
+            os: ubuntu-latest
+            python: 3.7
+
+          - name: Python 3.8
+            os: ubuntu-latest
+            python: 3.8
+
+          - name: OS X - Python 3.8
+            os: macos-latest
+            python: 3.8
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up python ${{ matrix.python }} on ${{ matrix.os }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install base dependencies
+      run: |
+        $CONDA/bin/conda env update --file environment.yml --name base
+    - name: Test with pytest
+      run: |
+        $CONDA/bin/conda install pytest
+        $CONDA/bin/pytest -m "not veryslow"
+
+  docs_test:
+    name: "docs_test"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up python 3.7 on ubuntu-latest
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install base dependencies
+      run: |
+        $CONDA/bin/conda env update --file .rtd-environment.yml --name base
+    - name: Test with pytest
+      run: |
+        $CONDA/bin/python setup.py build_docs -w
+
+  slow_test:
+    name: "slow_test"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up python 3.7 on ubuntu-latest
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install base dependencies
+      run: |
+        $CONDA/bin/conda env update --file environment.yml --name base
+    - name: Test with pytest
+      run: |
+        $CONDA/bin/conda install pytest
+        $CONDA/bin/pytest

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -79,7 +79,7 @@ jobs:
         python-version: 3.8
     - name: Install base dependencies
       run: |
-        sudo chown 501:20 /usr/local/miniconda/pkgs/cache/*.json
+        sudo chown -R 501:20 /usr/local/miniconda
         $CONDA/bin/conda env update --file environment.yml --name base
     - name: Install Required Data
       run: |

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Install base dependencies
       run: |
         sudo chown -R 501:20 /usr/local/miniconda
-        $CONDA/bin/conda env update --file environment.yml --name base
+        $CONDA/bin/conda env update --file environment.yml --name base -v
     - name: Install Required Data
       run: |
         mkdir test_data

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -79,6 +79,7 @@ jobs:
         python-version: 3.8
     - name: Install base dependencies
       run: |
+        sudo chown 501:20 /usr/local/miniconda/pkgs/cache/*.json
         $CONDA/bin/conda env update --file environment.yml --name base
     - name: Install Required Data
       run: |

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -31,13 +31,13 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Set up python ${{ matrix.python }} on ${{ matrix.os }}
-      uses: actions/setup-python@v2
+    - name: Set up environment
+      uses: conda-incubator/setup-miniconda@v2
       with:
+        activate-environment: stips
+        environment-file: environment.yml
         python-version: ${{ matrix.python }}
-    - name: Install base dependencies
-      run: |
-        $CONDA/bin/conda env update --file environment.yml --name base
+        auto-activate-base: false
     - name: Install Required Data
       run: |
         mkdir test_data
@@ -57,13 +57,14 @@ jobs:
         wget -qO- https://stsci.box.com/shared/static/qcptcokkbx7fgi3c00w2732yezkxzb99.gz -O test_data/webbpsf_data.gz
         tar -xzvf test_data/webbpsf_data.gz -C test_data/
     - name: Test with pytest
+      shell: bash -l {0}
       run: |
         export stips_data=./test_data/stips_data
         export PYSYN_CDBS=./test_data/synphot/grp/hst/cdbs
         export pandeia_refdata=./test_data/pandeia_data-1.5.2rc2_roman
         export WEBBPSF_PATH=./test_data/webbpsf-data
-        $CONDA/bin/conda install pytest
-        $CONDA/bin/pytest -m "not veryslow" stips
+        conda install pytest
+        pytest -m "not veryslow" stips
 
   mac_ci_test:
     name: macOS - Python 3.8
@@ -99,13 +100,14 @@ jobs:
         wget -qO- https://stsci.box.com/shared/static/qcptcokkbx7fgi3c00w2732yezkxzb99.gz -O test_data/webbpsf_data.gz
         tar -xzvf test_data/webbpsf_data.gz -C test_data/
     - name: Test with pytest
+      shell: bash -l {0}
       run: |
         export stips_data=./test_data/stips_data
         export PYSYN_CDBS=./test_data/synphot/grp/hst/cdbs
         export pandeia_refdata=./test_data/pandeia_data-1.5.2rc2_roman
         export WEBBPSF_PATH=./test_data/webbpsf-data
         conda install pytest
-        $CONDA/envs/stips/bin/pytest -m "not veryslow" stips
+        pytest -m "not veryslow" stips
 
   docs_test:
     name: "docs_test"
@@ -115,16 +117,17 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Set up python 3.7 on ubuntu-latest
-      uses: actions/setup-python@v2
+    - name: Set up environment
+      uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.7
-    - name: Install base dependencies
-      run: |
-        $CONDA/bin/conda env update --file .rtd-environment.yml --name base
+        activate-environment: stips
+        environment-file: environment.yml
+        python-version: 3.8
+        auto-activate-base: false
     - name: Build Docs
+      shell: bash -l {0}
       run: |
-        $CONDA/bin/python setup.py build_docs -w
+        python setup.py build_docs -w
 
   slow_test:
     name: "slow_test"
@@ -134,13 +137,13 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Set up python 3.7 on ubuntu-latest
-      uses: actions/setup-python@v2
+    - name: Set up environment
+      uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.7
-    - name: Install base dependencies
-      run: |
-        $CONDA/bin/conda env update --file environment.yml --name base
+        activate-environment: stips
+        environment-file: environment.yml
+        python-version: 3.8
+        auto-activate-base: false
     - name: Install Required Data
       run: |
         mkdir test_data
@@ -160,11 +163,12 @@ jobs:
         wget -qO- https://stsci.box.com/shared/static/qcptcokkbx7fgi3c00w2732yezkxzb99.gz -O test_data/webbpsf_data.gz
         tar -xzvf test_data/webbpsf_data.gz -C test_data/
     - name: Test with pytest
+      shell: bash -l {0}
       run: |
         export stips_data=./test_data/stips_data
         export PYSYN_CDBS=./test_data/synphot/grp/hst/cdbs
         export pandeia_refdata=./test_data/pandeia_data-1.5.2rc2_roman
         export WEBBPSF_PATH=./test_data/webbpsf-data
-        $CONDA/bin/conda install pytest
-        $CONDA/bin/pytest stips
+        conda install pytest
+        pytest stips
 

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -73,14 +73,13 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Set up python 3.8 on macos-latest
-      uses: actions/setup-python@v2
+    - name: Set up environment
+      uses: conda-incubator/setup-miniconda@v2
       with:
+        activate-environment: test
+        environment-file: environment.yml
         python-version: 3.8
-    - name: Install base dependencies
-      run: |
-        sudo chown -R 501:20 /usr/local/miniconda
-        $CONDA/bin/conda env update --file environment.yml --name base -v
+        auto-activate-base: false
     - name: Install Required Data
       run: |
         mkdir test_data
@@ -105,8 +104,8 @@ jobs:
         export PYSYN_CDBS=./test_data/synphot/grp/hst/cdbs
         export pandeia_refdata=./test_data/pandeia_data-1.5.2rc2_roman
         export WEBBPSF_PATH=./test_data/webbpsf-data
-        $CONDA/bin/conda install pytest
-        $CONDA/bin/pytest -m "not veryslow" stips
+        conda install pytest
+        pytest -m "not veryslow" stips
 
   docs_test:
     name: "docs_test"

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -57,8 +57,7 @@ jobs:
         python-version: 3.8
     - name: Install base dependencies
       run: |
-        sudo chown 501:20 /usr/local/miniconda/pkgs/cache/31ce02e0.json
-        $CONDA/bin/conda env update --file environment.yml --name base
+        sudo $CONDA/bin/conda env update --file environment.yml --name base
     - name: Test with pytest
       run: |
         $CONDA/bin/conda install pytest
@@ -123,5 +122,5 @@ jobs:
         export pandeia_refdata=./test_data/pandeia_data-1.5.2rc2_roman
         export WEBBPSF_PATH=./test_data/webbpsf-data
         $CONDA/bin/conda install pytest
-        $CONDA/bin/pytest
+        $CONDA/bin/pytest stips
 


### PR DESCRIPTION
This should replicate the existing Travis CI suite in Github actions. Once we're sure it's working, we can turn off Travis.