### PR TITLE
Updated ReadTheDocs config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,26 +1,33 @@
-# .readthedocs.yaml
-# Read the Docs configuration file
+# Read the Docs configuration file for Sphinx projects
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
 version: 2
 
-# Build documentation in the docs/ directory with Sphinx
-sphinx:
-   configuration: docs/conf.py
-
-# Optionally build your docs in additional formats such as PDF
-#formats:
-#   - pdf
-
-conda:
-  environment: environment.yml
-
+# Set the OS, Python version and other tools you might need
 build:
-  image: testing
+  os: ubuntu-22.04 # (now required to build RTD)
+  tools:
+    python: "3.12"
+    # You can also specify other tool versions:
+    # nodejs: "20"
 
-# Optionally set the version of Python and requirements required to build your docs
-#python:
-#   version: 3.9
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#   - pdf
+#   - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
 #   install:
-#   - requirements: docs/requirements.txt
+#     - requirements: docs/requirements.txt


### PR DESCRIPTION
I copied in [an updated template](https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os) for `.readthedocs.yaml`. Recent RTD builds have failed because we hadn't been specifying the `build os` parameter [that is now required](https://github.com/readthedocs/readthedocs.org/issues/8912) in all images.