### PR TITLE
Use latest stsci_rtd_theme commit in docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,6 @@
-stsci_rtd_theme
+git+https://github.com/spacetelescope/stsci_rtd_theme.git@master#egg=stsci_rtd_theme
+# (install stsci_rtd_theme from master until a post 1.0 release occurs
+#  to prevent issues with bullets in the documentation)
 numpy >= 1.13
 matplotlib
 Cython


### PR DESCRIPTION
For now, we need to use `master` branch of `stsci_rtd_theme` instead of the latest release (currently v1.0.0) in order to get a fix that helps bullet characters render correctly. We made this fix for the locally generated Sphinx documentation and now need to do the same for the requirements file used by ReadTheDocs. This is the same issue that's been referenced in a couple of [previous comments](https://github.com/spacetelescope/STScI-STIPS/pull/163/#pullrequestreview-1081339571) from [other pull requests](https://github.com/spacetelescope/STScI-STIPS/pull/167#pullrequestreview-1663613852).