### PR TITLE
Change stray WFIRST mention to Roman

### DIFF
--- a/stips/astro_image/astro_image.py
+++ b/stips/astro_image/astro_image.py
@@ -373,7 +373,7 @@ class AstroImage(object):
     def psf_constructor(self):
         import webbpsf
         if not hasattr(webbpsf, self.telescope.lower()) and self.telescope.lower() == 'roman':
-            return getattr(getattr(webbpsf, 'wfirst'), self.instrument)()
+            return getattr(getattr(webbpsf, 'roman'), self.instrument)()
         if hasattr(webbpsf, self.instrument):
             return getattr(webbpsf, self.instrument)()
         return getattr(getattr(webbpsf, self.telescope), self.instrument)()


### PR DESCRIPTION
There's a mention of `"wfirst"` in an if/else clause in `astro_image.py` that will cause an error if triggered, so I adjusted it to `"roman"`. `grep` says the only other times WFIRST appears are in comments referring to specific documents, so this should resolve #95.