### PR TITLE
Change remaining mentions of master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # STScI-STIPS
 
-[![Build Status](https://travis-ci.com/spacetelescope/STScI-STIPS.svg?branch=master)](https://travis-ci.com/spacetelescope/STScI-STIPS)
+[![Build Status](https://github.com/spacetelescope/STScI-STIPS/actions/workflows/ci_workflows.yml/badge.svg?branch=main)](https://github.com/spacetelescope/STScI-STIPS/actions/workflows/ci_workflows.yml?query=branch:main)
 [![STScI](https://img.shields.io/badge/powered%20by-STScI-blue.svg?colorA=707170&colorB=3e8ddd&style=flat)](http://www.stsci.edu)
 
 For documentation and installation instructions please visit https://stips.readthedocs.io
@@ -12,32 +12,32 @@ For documentation and installation instructions please visit https://stips.readt
 
 ## Overview
 
-STIPS is the Space Telescope Imaging Product Simulator. It is designed to create 
-simulations of full-detector post-pipeline astronomical scenes for the Nancy Grace Roman 
-Space Telescope's Wide-Field Instrument (WFI). STIPS has the ability to add 
+STIPS is the Space Telescope Imaging Product Simulator. It is designed to create
+simulations of full-detector post-pipeline astronomical scenes for the Nancy Grace Roman
+Space Telescope's Wide-Field Instrument (WFI). STIPS has the ability to add
 instrumental distortion (if available) as well as calibration residuals from flatfields,
 dark currents, and cosmic rays. It automatically includes Poisson noise and readout noise.
 It does not include instrument saturation effects.
 
 ## Why use STIPS?
 
-STIPS is intended to produce quick simulations of Level 2 (L2) images, and is provided for 
+STIPS is intended to produce quick simulations of Level 2 (L2) images, and is provided for
 cases where [Pandeia](https://pypi.org/project/pandeia.engine) does not
 provide a large enough simulation area (e.g., full-detector or multiple-detector
 observations). STIPS obtains its Roman instrument and filter values from
 Pandeia, so it should produce output within 10% of output produced by Pandeia.
 
-STIPS does not start with Level 1 (L1) images and propagate instrumental calibrations 
+STIPS does not start with Level 1 (L1) images and propagate instrumental calibrations
 through the simulations. While it does have the ability to add error residuals (representing
-the remaining uncertainty after pipeline calibration), these residuals are not validated 
-against actual pipeline calibrations of L1 images. STIPS is not the ideal choice if 
-extremely good instrumental accuracy is needed. Pandeia is the preferred tool for 
+the remaining uncertainty after pipeline calibration), these residuals are not validated
+against actual pipeline calibrations of L1 images. STIPS is not the ideal choice if
+extremely good instrumental accuracy is needed. Pandeia is the preferred tool for
 high-accuracy observations.
 
 Developed by Brian York ([@york-stsci](https://github.com/york-stsci)),
-Robel Geda ([@robelgeda](https://github.com/robelgeda)), and 
+Robel Geda ([@robelgeda](https://github.com/robelgeda)), and
 O. Justin Otor ([@ojustino](https://github.com/ojustino)).
-Python ePSF code developed by 
+Python ePSF code developed by
 Sebastian Gomez ([@gmzsebastian](https://github.com/gmzsebastian)) based on Fortran code
 developed by Andrea Bellini ([@AndreaBellini](https://github.com/AndreaBellini)).
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -180,7 +180,7 @@ if eval(setup_cfg.get('edit_on_github')):
     if versionmod.version.release:
         edit_on_github_branch = "v" + versionmod.version.version
     else:
-        edit_on_github_branch = "master"
+        edit_on_github_branch = "main"
 
     edit_on_github_source_root = ""
     edit_on_github_doc_root = "docs"


### PR DESCRIPTION
We switched the `master` branch to `main` after the release of version 2.2.0, so I used `grep` to find remaining mentions of the former name and then modified them in this pull request. I also changed the status badge URL from Travis to GitHub Actions to reflect the previous change of CI providers.