### PR TITLE
STIPS 2.2.1 Pull Request (v2)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Release Notes
 Version History and Change Log
 ------------------------------
 
+Version 2.2.1
+=============
+- Fixed a bug on the version of STIPS in __init__.py
+- Updated WebbPSF version to be >= 1.1.1 instead of == 1.1.1
+
 Version 2.2.0
 =============
 - Added a functionality to allow for faster simulations of extended sources.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Version 2.2.1
 =============
 - Fixed a bug on the version of STIPS in __init__.py
 - Updated WebbPSF version to be >= 1.1.1 instead of == 1.1.1
+- Updated synphot>=1.1.1 and stsynphot>=1.1.0 from forced to specific version.
 
 Version 2.2.0
 =============

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,7 +11,7 @@ STIPS Requirements
 
 * ``pandeia>=3.1``: Exposure time calculator.
 
-* ``webbpsf==1.1.1``: Nancy Grace Roman PSF calculator. STIPS also requires that ``poppy``, a
+* ``webbpsf>=1.1.1``: Nancy Grace Roman PSF calculator. STIPS also requires that ``poppy``, a
   support package used by WebbPSF, have version ``>=1.0.3``.
 
 * ``astropy``: STIPS uses Astropy in order to:

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -16,7 +16,7 @@ In addition to addressing any byproducts of the code review, you should be able
 to answer "yes" to all of the following questions before merging a pull request
 intended for a release:
 
-* Has ``setup.cfg`` been updated to reflect the release's new version number?
+* Have ``setup.cfg`` and ``stips/__init__.py`` been updated to reflect the release's new version number?
 
 * If any dependencies have changed, have you updated them in all applicable files? These include:
 

--- a/environment.yml
+++ b/environment.yml
@@ -35,7 +35,7 @@ dependencies:
     - poppy==1.0.3
 
     # Core Modules
-    - webbpsf==1.1.1
+    - webbpsf>=1.1.1
     - pandeia.engine==3.1
     - synphot==1.1.1
     - stsynphot==1.1.0

--- a/environment.yml
+++ b/environment.yml
@@ -37,8 +37,8 @@ dependencies:
     # Core Modules
     - webbpsf>=1.1.1
     - pandeia.engine==3.1
-    - synphot==1.1.1
-    - stsynphot==1.1.0
+    - synphot>=1.1.1
+    - stsynphot>=1.1.0
     - soc_roman_tools
 
     # Major modules

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -46,8 +46,8 @@ dependencies:
     # Core Modules
     - webbpsf>=1.1.1
     - pandeia.engine==3.1
-    - synphot==1.1.1
-    - stsynphot==1.1.0
+    - synphot>=1.1.1
+    - stsynphot>=1.1.0
     - soc_roman_tools
 
     # Major modules

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -44,7 +44,7 @@ dependencies:
     - poppy==1.0.3
 
     # Core Modules
-    - webbpsf==1.1.1
+    - webbpsf>=1.1.1
     - pandeia.engine==3.1
     - synphot==1.1.1
     - stsynphot==1.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,8 @@ install_requires =
     numpy
     scipy
     photutils
-    synphot==1.1.1
-    stsynphot==1.1.0
+    synphot>=1.1.1
+    stsynphot>=1.1.0
     webbpsf>=1.1.1
     pandeia.engine==3.1
     montage-wrapper

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = stips
 # version should be PEP440 compatible (https://www.python.org/dev/peps/pep-0440/)
-version = 2.2.0
+version = 2.2.1
 author = Space Telescope Science Institute
 author_email = york@stsci.edu
 description = STIPS is the Space Telescope Imaging Product Simulator.
@@ -23,7 +23,7 @@ install_requires =
     photutils
     synphot==1.1.1
     stsynphot==1.1.0
-    webbpsf==1.1.1
+    webbpsf>=1.1.1
     pandeia.engine==3.1
     montage-wrapper
     pyyaml

--- a/stips/__init__.py
+++ b/stips/__init__.py
@@ -4,7 +4,7 @@ import os
 
 __all__ = ['observation_module', 'scene_module']
 
-__version__ = "2.1.0"
+__version__ = "2.2.1"
 version = __version__
 
 from .utilities import SetupDataPaths


### PR DESCRIPTION
- Fixed a bug on the version of STIPS in `__init__.py`
- Updated WebbPSF version to be >= 1.1.1 instead of == 1.1.1
- Updated synphot>=1.1.1 and stsynphot>=1.1.0 from forced to specific version.