### PR TITLE
STIPS 2.2.2 Pull Request

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Release Notes
 Version History and Change Log
 ------------------------------
 
+Version 2.2.2
+=============
+- Updated pandeia.engine version to be >= 3.1 instead of == 3.1
+
 Version 2.2.1
 =============
 - Fixed a bug on the version of STIPS in __init__.py

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -24,6 +24,7 @@ intended for a release:
     * ``environment.yml``
     * ``environment_dev.yml``
     * ``docs/installation.rst``
+    * ``ret_data/retrieve_stips_data.py``
 
 * Are you able to install the new version of STIPS locally with ``pip`` and ``conda``?
 

--- a/environment.yml
+++ b/environment.yml
@@ -36,7 +36,7 @@ dependencies:
 
     # Core Modules
     - webbpsf>=1.1.1
-    - pandeia.engine==3.1
+    - pandeia.engine>=3.1
     - synphot>=1.1.1
     - stsynphot>=1.1.0
     - soc_roman_tools

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -45,7 +45,7 @@ dependencies:
 
     # Core Modules
     - webbpsf>=1.1.1
-    - pandeia.engine==3.1
+    - pandeia.engine>=3.1
     - synphot>=1.1.1
     - stsynphot>=1.1.0
     - soc_roman_tools

--- a/ref_data/retrieve_stips_data.py
+++ b/ref_data/retrieve_stips_data.py
@@ -6,7 +6,7 @@
 #       export WEBBPSF_PATH="<absolute_path_to_this_folder>/ref_data/webbpsf-data"
 #       export PYSYN_CDBS="<absolute_path_to_this_folder>/ref_data/grp/redcat/trds"
 #       export pandeia_refdata="<absolute_path_to_this_folder>/ref_data/pandeia_data-
-#       1.7_roman"
+#       2024.12-roman"
 # 2. In the ref_data folder, run the script: python retrieve_stips_data.py
 
 import stips

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     synphot>=1.1.1
     stsynphot>=1.1.0
     webbpsf>=1.1.1
-    pandeia.engine==3.1
+    pandeia.engine>=3.1
     montage-wrapper
     pyyaml
     soc_roman_tools

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = stips
 # version should be PEP440 compatible (https://www.python.org/dev/peps/pep-0440/)
-version = 2.2.1
+version = 2.2.2
 author = Space Telescope Science Institute
 author_email = york@stsci.edu
 description = STIPS is the Space Telescope Imaging Product Simulator.

--- a/stips/__init__.py
+++ b/stips/__init__.py
@@ -4,7 +4,7 @@ import os
 
 __all__ = ['observation_module', 'scene_module']
 
-__version__ = "2.2.1"
+__version__ = "2.2.2"
 version = __version__
 
 from .utilities import SetupDataPaths


### PR DESCRIPTION
Updated the following files to have installation requirement of pandeia.engine to be >=3.1. 

- CHANGES.rst
- docs/release.rst
- environment.yml
- environment_dev.yml
- ref_data/retrieve_stips_data.py
- setup.cfg
- stips/__init__.py
