### PR TITLE
Remove bad envs from RTD

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -2,9 +2,6 @@ name: stips
 
 channels:
   - conda-forge
-  - astropy
-  - http://ssb.stsci.edu/astroconda
-  - defaults
 
 dependencies:
   - python>=3.7

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python>=3.7
+  - python>=3.10
   - astropy
 
   # Docs

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,6 @@ name: stips
 
 channels:
   - conda-forge
-  - astropy
 
 dependencies:
   # Base dependencies

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -22,7 +22,6 @@ name: stips_dev
 
 channels:
   - conda-forge
-  - astropy
 
 dependencies:
   # Base dependencies


### PR DESCRIPTION
Removing "defaults" channel as ordered by CE. Also remove other defunct channels.