### PR TITLE
Attempted to create API documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,4 +30,5 @@ sphinx:
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
-    - requirements: docs/requirements.txt
+    - method: pip
+      path: .[docs]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,36 @@
+API Documentation
+=================
+
+This section contains API documentation from the STIPS source code.
+
+User-facing classes
+-------------------
+..
+  Dev notes:
+  * Only objects listed in __all__ at the top of a script will be listed.
+  * stips.scene_module.convert_units skipped intentionally as less relevant to general users.
+
+.. automodapi:: stips.observation_module.observation_module
+   :headings: ^"
+.. automodapi:: stips.scene_module.scene_module
+   :headings: ^"
+
+Other classes
+-------------
+..
+  Dev notes:
+  * Only objects listed in __all__ at the top of a script will be listed.
+  * stips.data and stips.utilities skipped intentionally as less relevant to general users.
+
+.. automodapi:: stips.astro_image.astro_image
+   :headings: ^"
+.. automodapi:: stips.stellar_module.star_generator
+   :headings: ^"
+.. automodapi:: stips.errors.make_cosmic_ray
+   :headings: ^"
+.. automodapi:: stips.instruments.instrument
+   :headings: ^"
+.. automodapi:: stips.instruments.roman_instrument
+   :headings: ^"
+.. automodapi:: stips.instruments.wfi
+   :headings: ^"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,10 +67,19 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'sphinx_rtd_theme',
-    'sphinx_issues'
+    'sphinx_issues',
+    'sphinx_automodapi.automodapi',
 ]
 
 numpydoc_show_class_members = False
+
+automodapi_toctree_template = "automodapi_toctree.rst"
+automodapi_inheritance_diagram = False
+
+autodoc_default_options = {
+    'inherited-members': False,
+    'show-inheritance': True,
+}
 
 # ignore checkpoint paths when generating API docs
 autoapi_ignore = ['*.ipynb_checkpoints*']
@@ -170,7 +179,7 @@ autoapi_dirs = ["../stips"]
 #
 # NOTE that this will also suppress module-not-found errors, but hopefully the run tests
 # will handle anything of the sort.
-suppress_warnings = ["autoapi.python_import_resolution"]
+suppress_warnings = ["autoapi.python_import_resolution", "toc.not_included"]
 
 # -- Options for the edit_on_github extension ---------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,3 +55,4 @@ Using STIPS
   bugs
   release
   help
+  api

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -56,7 +56,6 @@ intended for a release:
     * ``environment.yml``
     * ``environment_dev.yml``
     * ``docs/installation.rst``
-    * ``docs/requirements.txt``
     * ``ref_data/retrieve_stips_data.py``
     * ``utilities/utilities.py`` (if any reference data links have changed)
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,1 @@
-stsci_rtd_theme
-numpy >= 1.13
-matplotlib
-Cython
-astropy
-sphinx-astropy
-sphinx_issues
-poppy >= 1.0.3
+-e .[docs]

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,12 @@ include_package_data = True
 stips = data/*
 stips.tests = coveragerc
 
+[options.extras_require]
+docs =
+    sphinx-astropy
+    sphinx_issues
+    stsci_rtd_theme
+
 [build_sphinx]
 source-dir = docs
 build-dir = docs/_build

--- a/stips/astro_image/astro_image.py
+++ b/stips/astro_image/astro_image.py
@@ -28,20 +28,21 @@ from ..utilities.makePSF import interpolate_epsf, make_epsf, place_source
 # PSF constants
 from ..utilities.makePSF import PSF_BOXSIZE, PSF_BRIGHT_BOXSIZE, PSF_EXTRA_BRIGHT_BOXSIZE, PSF_GRID_SIZE, PSF_UPSCALE
 
+__all__ = ['AstroImage']
 stips_version = StipsEnvironment.__stips__version__
 
 
 class AstroImage(object):
     """
-    The AstroImage class represents a generic astronomical image. The image has the following
-    data associated with it:
-        _file   : string of file name (including path) containing mem-mapped numpy array.
-        data    : mem-mapped numpy double-precision 2D array of image data, in counts
-        scale   : array of 2 double-precision floating point values, forming X and Y scale in
-                  arcseconds/pixel
-        wcs     : astropy WCS object containing image WCS information.
-        header  : key/value array. Contains FITS header information and metadata
-        history : array of strings holding the FITS HISTORY section
+    The AstroImage class represents a generic astronomical image. The image has
+    the following data associated with it:
+
+    - _file   : string of file name (including path) containing mem-mapped numpy array.
+    - data    : mem-mapped numpy double-precision 2D array of image data, in counts
+    - scale   : array of 2 double-precision floating point values, forming X and Y scale in arcseconds/pixel
+    - wcs     : astropy WCS object containing image WCS information.
+    - header  : key/value array. Contains FITS header information and metadata
+    - history : array of strings holding the FITS HISTORY section
     """
 
     def __init__(self, **kwargs):
@@ -400,6 +401,7 @@ class AstroImage(object):
     def addTable(self, t, dist=False, fast_galaxy=False, convolve_galaxy=True, *args, **kwargs):
         """
         Add a catalogue table to the Image. The Table must have the following columns:
+
             RA: RA of source
             DEC: DEC of source
             FLUX: flux of source
@@ -410,11 +412,14 @@ class AstroImage(object):
             Ratio: axial ratio of the Sersic profile
             ID: id of source in catalogue
             Notes: any notes of important
+
         The following will then be done:
+
             - the table will be shifted from RA,DEC to X,Y (and items outside the FOV will be omitted)
             - the table will be split into point sources and sersic profiles
             - the point sources will be added via addPoints
             - the Sersic Profiles will be iteratively added via addSersicProfile
+
         The converted table (with X,Y instead of ra,dec and non-visible points removed) will be returned.
         """
         self._log("info", "Determining pixel co-ordinates")
@@ -505,19 +510,22 @@ class AstroImage(object):
     def addCatalogue(self, cat, dist=False, *args, **kwargs):
         """
         Add a catalogue to the Image. The Catalogue must have the following columns:
-            RA: RA of source
-            DEC: DEC of source
-            FLUX: flux of source
-            TYPE: type of source (point, sersic)
-            N: sersic index
-            Re: radius containing half of the light of the sersic profile
-            Phi: angle of the major axis of the sersic profile
-            Ratio: axial ratio of the Sersic profile
-            ID: id of source in catalogue
-            Notes: any notes of important
+
+            - RA: RA of source
+            - DEC: DEC of source
+            - FLUX: flux of source
+            - TYPE: type of source (point, sersic)
+            - N: sersic index
+            - Re: radius containing half of the light of the sersic profile
+            - Phi: angle of the major axis of the sersic profile
+            - Ratio: axial ratio of the Sersic profile
+            - ID: id of source in catalogue
+            - Notes: any notes of important
+
         The following will then be done:
-            - the catalogue will be shifted from RA,DEC to X,Y (and items outside the FOV will be
-                omitted)
+
+            - the catalogue will be shifted from RA,DEC to X,Y
+              (and items outside the FOV will be omitted)
             - the catalogue will be split into point sources and sersic profiles
             - the point sources will be added via addPoints
             - the Sersic Profiles will be iteratively added via addSersicProfile
@@ -1305,7 +1313,7 @@ class AstroImage(object):
         world_coords = np.array((wcs.wcs.crval, wcs.wcs.crval+offset_value))
         pix_coords = wcs.wcs_world2pix(world_coords, self.wcs_origin)
         offset = (pix_coords[1] - pix_coords[0])
-#         offset = offset / scale # Divide by scale to correct for non-square pixels
+        # offset = offset / scale # Divide by scale to correct for non-square pixels
         pa_north = np.degrees(np.arctan2(offset[0], offset[1])) % 360. % 360.
         return pa_north
 
@@ -1415,3 +1423,4 @@ class AstroImage(object):
                             'photflam': 0.,
                             'photplam': 0.6700,
                          }
+    "Default instrument configuration dictionary."

--- a/stips/errors/make_cosmic_ray.py
+++ b/stips/errors/make_cosmic_ray.py
@@ -1,6 +1,7 @@
 """
 Functions to simulate cosmic rays.
-
+"""
+"""
 :Authors: Pey Lian Lim (Python); Mike Regan (IDL)
 
 :Organization: Space Telescope Science Institute
@@ -12,6 +13,8 @@ Functions to simulate cosmic rays.
 
 # External modules
 import numpy as np
+
+__all__ = ['GaussPsf2D', 'MakeCosmicRay', 'GetCrTemplate', 'GetCrProbs']
 
 
 def GaussPsf2D(npix, fwhm, normalize=True):

--- a/stips/instruments/instrument.py
+++ b/stips/instruments/instrument.py
@@ -21,14 +21,17 @@ from ..astro_image import AstroImage
 from ..utilities import GetStipsData, OffsetPosition, SelectParameter, get_pandeia_background, StipsDataTable
 from ..utilities.makePSF import PSF_GRID_SIZE
 
+__all__ = ['Instrument']
+
+
 class Instrument(object):
     """
-    The Instrument class represents a virtual base class which will be implemented as a variety of
-        JWST, HST, and Roman actual instruments. The Instrument class contains:
+    The Instrument class represents a virtual base class which can be
+    implemented as a variety of actual Roman instruments. The Instrument class contains:
 
-        detectors : array of detectors, each an AstroImage, and each with its own RA/DEC
-        filter    : string, what filter of the instrument is being observed
-        out_path  : place to put temporary files and the like
+        - detectors : array of detectors, each an AstroImage, and each with its own RA/DEC
+        - filter    : string, what filter of the instrument is being observed
+        - out_path  : place to put temporary files and the like
     """
 
     def __init__(self, **kwargs):
@@ -110,16 +113,18 @@ class Instrument(object):
             Takes an input catalogue, and observes that catalogue with all detectors.
 
             It currently assumes that the input catalogue has the following columns:
-                RA: RA of source
-                DEC: DEC of source
-                FLUX: flux of source
-                TYPE: type of source (point, sersic)
-                N: sersic index
-                Re: radius containing half of the light of the sersic profile
-                Phi: angle of the major axis of the sersic profile
-                Ratio: axial ratio of the Sersic profile
-            Obtaining the correct values for FLUX (if not done before initialization) is a job for
-            the subclasses.
+
+                - RA: RA of source
+                - DEC: DEC of source
+                - FLUX: flux of source
+                - TYPE: type of source (point, sersic)
+                - N: sersic index
+                - Re: radius containing half of the light of the sersic profile
+                - Phi: angle of the major axis of the sersic profile
+                - Ratio: axial ratio of the Sersic profile
+
+            Obtaining the correct values for FLUX (if not done before
+            initialization) is a job for the subclasses.
         """
         cls._log("info", "Initializing with catalogue {}".format(catalogue))
         ins = cls(**kwargs)
@@ -241,16 +246,18 @@ class Instrument(object):
             Takes an input catalogue, and observes that catalogue with all detectors.
 
             It currently assumes that the input catalogue has the following columns:
-                RA: RA of source
-                DEC: DEC of source
-                FLUX: flux of source
-                TYPE: type of source (point, sersic)
-                N: sersic index
-                Re: radius containing half of the light of the sersic profile
-                Phi: angle of the major axis of the sersic profile
-                Ratio: axial ratio of the Sersic profile
-            Obtaining the correct values for FLUX (if not done before initialization) is a job for
-            the subclasses.
+
+                - RA: RA of source
+                - DEC: DEC of source
+                - FLUX: flux of source
+                - TYPE: type of source (point, sersic)
+                - N: sersic index
+                - Re: radius containing half of the light of the sersic profile
+                - Phi: angle of the major axis of the sersic profile
+                - Ratio: axial ratio of the Sersic profile
+
+            Obtaining the correct values for FLUX (if not done before
+            initialization) is a job for the subclasses.
         """
         self._log("info", "Adding catalogue {}".format(catalogue))
         cat = self.convertCatalogue(catalogue, obs_num)
@@ -318,14 +325,14 @@ class Instrument(object):
 
     def convertCatalogue(self, catalogue, obs_num):
         """
-        Converts a catalogue to the expected format for AstroImage, including doing unit conversions
-        of columns if necessary. Acceptable formats are:
+        Converts a catalogue to the expected format for AstroImage, including
+        doing unit conversions of columns if necessary. Acceptable formats are:
+
             - Phoenix (models from the Phoenix stellar grid)
             - BC95 (galaxy models from BC95)
             - Internal (has columns RA/DEC/FLUX/TYPE/N/Re/Phi/Ratio/ID/Notes)
             - Mixed (has columns RA/DEC/FLUX/UNITS/TYPE/N/Re/Phi/Ratio/ID/Notes)
-            - Generic (has columns RA/DEC/FILTER where FILTER == self.filter (and possibly also
-                       other filters)
+            - Generic (has columns RA/DEC/FILTER where FILTER == self.filter and possibly also other filters)
 
         catalogue: catalogue name of input catalogue
 
@@ -343,22 +350,22 @@ class Instrument(object):
             meta = {k.lower(): v for k, v in in_data_table.meta.items()}
         # Check for built-in metadata
         table_type = ""
-#         if 'keywords' in in_meta:
-#             if 'type' in in_meta['keywords']:
-#                 table_type = in_meta['keywords']['type']['value']
+        # if 'keywords' in in_meta:
+        #     if 'type' in in_meta['keywords']:
+        #         table_type = in_meta['keywords']['type']['value']
         if 'type' in meta:
             table_type = meta['type']
         if table_type in ['phoenix', 'phoenix_realtime', 'bc95']:
             pass
         elif table_type == 'internal':
             filter = meta['filter'].lower()
-#             filter = t.meta['keywords']['filter']['value'].lower()
+            # filter = t.meta['keywords']['filter']['value'].lower()
             if filter != self.filter.lower():
                 raise ValueError("Adding catalogue with filter {} to {} {}".format(filter, self.DETECTOR, self.filter))
             return catalogue
         elif table_type == 'mixed':
             filter = meta['filter'].lower()
-#             filter = t.meta['keywords']['filter']['value'].lower()
+            # filter = t.meta['keywords']['filter']['value'].lower()
             if filter != self.filter.lower():
                 raise ValueError("Adding catalogue with filter {} to {} {}".format(filter, self.DETECTOR, self.filter))
         elif table_type == 'multifilter':

--- a/stips/instruments/roman_instrument.py
+++ b/stips/instruments/roman_instrument.py
@@ -3,16 +3,20 @@ __filetype__ = "base"
 # Local Modules
 from .instrument import Instrument
 
+__all__ = ['RomanInstrument']
+
 
 class RomanInstrument(Instrument):
     """
-    The RomanInstrument class contains the necessary constants and modifications specific to Roman
-        but independent of any specific instrument. This class is also not intended to be
-        implemented directly, but rather through its children (e.g. WFI).
-        It contains the following constants and the following new variables:
+    The RomanInstrument class contains the necessary constants and modifications
+    specific to Roman but independent of any specific instrument. This class is
+    also not intended to be implemented directly, but rather through its
+    children (e.g. WFI).
 
-        detectors : array of detectors, each an AstroImage, and each with its own RA/DEC
-        filter    : string, what filter of the instrument is being observed
+    It contains the following constants and the following new variables:
+
+        - detectors : array of detectors, each an AstroImage, and each with its own RA/DEC
+        - filter    : string, what filter of the instrument is being observed
     """
 
     def __init__(self, **kwargs):

--- a/stips/instruments/wfi.py
+++ b/stips/instruments/wfi.py
@@ -9,17 +9,19 @@ import numpy as np
 # Local Modules
 from .roman_instrument import RomanInstrument
 
+__all__ = ['WFI']
+
 
 class WFI(RomanInstrument):
-    __classtype__ = "detector"
     """
     The WFI class contains the necessary constants and modifications to run WFI
     observations.
 
-        detectors : array of detectors, each an AstroImage, and each with its own RA/DEC
-        instrument: string, which instrument this is
-        filter    : string, what filter of the instrument is being observed
+        - detectors : array of detectors, each an AstroImage, and each with its own RA/DEC
+        - instrument: string, which instrument this is
+        - filter    : string, what filter of the instrument is being observed
     """
+    __classtype__ = "detector"
 
     def __init__(self, **kwargs):
         """

--- a/stips/observation_module/observation_module.py
+++ b/stips/observation_module/observation_module.py
@@ -10,6 +10,8 @@ from ..utilities import OffsetPosition
 from ..utilities import SelectParameter
 from ..utilities.makePSF import PSF_GRID_SIZE
 
+__all__ = ['ObservationModule']
+
 
 class ObservationModule(object):
 

--- a/stips/scene_module/scene_module.py
+++ b/stips/scene_module/scene_module.py
@@ -14,6 +14,8 @@ from ..utilities import OffsetPosition
 from ..utilities import SelectParameter
 from ..utilities import StipsDataTable
 
+__all__ = ['SceneModule']
+
 
 class SceneModule(object):
 
@@ -79,15 +81,16 @@ class SceneModule(object):
         Generate a stellar population.
 
         Output list will have these columns:
-            # ID
-            # RA
-            # DEC
-            # Distance
-            # Age
-            # Metallicity
-            # Mass
-            # Count Rate (in the chosen instrument/filter), Absolute
-            # Count Rate (in the chosen instrument/filter), Observed
+
+            - ID
+            - RA
+            - DEC
+            - Distance
+            - Age
+            - Metallicity
+            - Mass
+            - Count Rate (in the chosen instrument/filter), Absolute
+            - Count Rate (in the chosen instrument/filter), Observed
 
         Parameters
         ----------
@@ -96,6 +99,7 @@ class SceneModule(object):
 
         pop: dictionary
             Information about the population. Includes:
+
                 n_stars: int
                     Number of stars
                 age_low,age_high: floating point
@@ -261,18 +265,19 @@ class SceneModule(object):
         Generate galaxies list.
 
         Output list will have these columns:
-            # ID
-            # RA
-            # DEC
-            # Redshift
-            # Model
-            # Age
-            # Profile
-            # Half-flux_radius
-            # Axial_ratio
-            # Position_angle
-            # Johnson,V absolute
-            # Johnson,V apparent
+
+            - ID
+            - RA
+            - DEC
+            - Redshift
+            - Model
+            - Age
+            - Profile
+            - Half-flux_radius
+            - Axial_ratio
+            - Position_angle
+            - Johnson,V absolute
+            - Johnson,V apparent
 
         Parameters
         ----------
@@ -281,6 +286,7 @@ class SceneModule(object):
 
         gals: dictionary
             Information about the galaxies. Includes:
+
                 n_gals: int
                     Number of galaxies
                 z_low,z_high: float

--- a/stips/stellar_module/star_generator.py
+++ b/stips/stellar_module/star_generator.py
@@ -1,5 +1,7 @@
 """
-Various codes to work with the initial mass function
+Various codes to work with the initial mass function.
+"""
+"""
 
 Written by Adam Ginsburg. Distributed under the MIT license (below):
 
@@ -38,6 +40,8 @@ from astropy import units as u
 from scipy.interpolate import RegularGridInterpolator
 
 from ..utilities import GetStipsData
+
+__all__ = ['StarGenerator']
 
 
 class StarGenerator(object):
@@ -165,24 +169,25 @@ class StarGenerator(object):
     def schechter(self, m, A=1, beta=2, m0=100, integral=False, **kwargs):
         """
         A Schechter function with arbitrary defaults
-        (integral may not be correct - exponent hasn't been dealt with at all)
+        (integral may not be correct - exponent hasn't been dealt with at all):
 
-        $$ A m^{-\\beta} e^{-m/m_0} $$
+            :math:`A m^{-\\beta} e^{-m/m_0}`
 
         Parameters
         ----------
-            m : np.ndarray
-                List of masses for which to compute the Schechter function
-            A : float
-                Arbitrary amplitude of the Schechter function
-            beta : float
-                Power law exponent
-            m0 : float
-                Characteristic mass (mass at which exponential decay takes over)
+        m : np.ndarray
+            List of masses for which to compute the Schechter function
+        A : float
+            Arbitrary amplitude of the Schechter function
+        beta : float
+            Power law exponent
+        m0 : float
+            Characteristic mass (mass at which exponential decay takes over)
 
         Returns
         -------
-            p(m) - the (unnormalized) probability of an object of a given mass
+        p(m)
+            the (unnormalized) probability of an object of a given mass
             as a function of that object's mass
             (though you could interpret mass as anything, it's just a number)
 
@@ -194,18 +199,20 @@ class StarGenerator(object):
     def modified_schechter(self, m, m1=0.5, **kwargs):
         """
         A Schechter function with a low-level exponential cutoff
-        "
+
         Parameters
         ----------
-            m : np.ndarray
-                List of masses for which to compute the Schechter function
-            m1 : float
-                Characteristic minimum mass (exponential decay below this mass)
-            ** See schecter for other parameters **
+        m : np.ndarray
+            List of masses for which to compute the Schechter function
+        m1 : float
+            Characteristic minimum mass (exponential decay below this mass)
+        kwargs
+            See :func:`schecter` for details
 
         Returns
         -------
-            p(m) - the (unnormalized) probability of an object of a given mass
+        p(m)
+            the (unnormalized) probability of an object of a given mass
             as a function of that object's mass
             (though you could interpret mass as anything, it's just a number)
         """
@@ -282,7 +289,7 @@ class StarGenerator(object):
                 countrates[np.where(mags > mags_max)] = countrates_max[np.where(mags > mags_max)]
         else:
             self.log('warning', 'Could not find result file "result_{}_{}.npy" from {}'.format(instrument.lower(), filter.lower(), self.gridpath))
-#             raise FileNotFoundError('Could not find result file "result_{}_{}.npy" from {}'.format(instrument.lower(), filter.lower(), self.gridpath))
+            # raise FileNotFoundError('Could not find result file "result_{}_{}.npy" from {}'.format(instrument.lower(), filter.lower(), self.gridpath))
             import synphot as syn
             import stsynphot as stsyn
             countrates = np.array(())


### PR DESCRIPTION
I did some work to fully resolve #137 that I'll memorialize here in case it becomes useful in the future. Everything works, but there are some classes and parameters that could use docstrings. [See them at this link.](https://stips--205.org.readthedocs.build/en/205/api.html)

I used `sphinx-automodapi` to handle creating the pages. It seems to need STIPS' full set of requirements as it pulls from the source code. We had been using a lighter set of requirements in `docs/requirements.txt` to keep sphinx builds brisk, but if all requirements are necessary, we may as well use the list from `setup.cfg`. I added the sphinx-specific extras to a new section there.